### PR TITLE
feat: add initial SQLAlchemy models and migration

### DIFF
--- a/apps/api/alembic.ini
+++ b/apps/api/alembic.ini
@@ -1,0 +1,35 @@
+[alembic]
+script_location = db/migrations
+sqlalchemy.url = sqlite:///./test.db
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = WARN
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s

--- a/apps/api/db/migrations/env.py
+++ b/apps/api/db/migrations/env.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config, pool
+from alembic import context
+
+from apps.api.src.models import Base  # type: ignore
+
+config = context.config
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=Base.metadata, literal_binds=True)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=Base.metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/apps/api/db/migrations/versions/20250902_0001_initial.py
+++ b/apps/api/db/migrations/versions/20250902_0001_initial.py
@@ -1,0 +1,113 @@
+"""initial tables
+
+Revision ID: 20250902_0001_initial
+Revises: 
+Create Date: 2025-09-02 00:01:00
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "20250902_0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "venues",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("code", sa.String(length=10), nullable=False, unique=True),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("prefecture", sa.String(length=100), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_table(
+        "races",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("venue_id", sa.Integer(), sa.ForeignKey("venues.id"), nullable=False),
+        sa.Column("date", sa.Date(), nullable=False),
+        sa.Column("race_no", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("grade", sa.String(length=20), nullable=False),
+        sa.Column("start_time", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("venue_id", "date", "race_no"),
+    )
+    op.create_index("idx_races_date_venue", "races", ["date", "venue_id"])
+
+    op.create_table(
+        "riders",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("registration_no", sa.Integer(), nullable=False, unique=True),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("birthplace", sa.String(length=100), nullable=False),
+        sa.Column("age", sa.Integer(), nullable=False),
+        sa.Column("klass", sa.String(length=20), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_table(
+        "race_entries",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("race_id", sa.Integer(), sa.ForeignKey("races.id"), nullable=False),
+        sa.Column("rider_id", sa.Integer(), sa.ForeignKey("riders.id"), nullable=False),
+        sa.Column("bike_no", sa.Integer(), nullable=False),
+        sa.Column("line_group", sa.String(length=50), nullable=False),
+        sa.Column("handicap", sa.String(length=50)),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint("race_id", "rider_id"),
+    )
+    op.create_index(
+        "idx_entries_race_bike", "race_entries", ["race_id", "bike_no"], unique=True
+    )
+
+    op.create_table(
+        "odds",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("race_id", sa.Integer(), sa.ForeignKey("races.id"), nullable=False),
+        sa.Column("bet_type", sa.String(length=20), nullable=False),
+        sa.Column("combo", sa.String(length=20), nullable=False),
+        sa.Column("odds", sa.Numeric(10, 2), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("idx_odds_race_bet", "odds", ["race_id", "bet_type"])
+
+    op.create_table(
+        "predictions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("race_id", sa.Integer(), sa.ForeignKey("races.id"), nullable=False),
+        sa.Column("model_version", sa.String(length=50), nullable=False),
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+    op.create_index("idx_pred_race", "predictions", ["race_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_pred_race", table_name="predictions")
+    op.drop_table("predictions")
+
+    op.drop_index("idx_odds_race_bet", table_name="odds")
+    op.drop_table("odds")
+
+    op.drop_index("idx_entries_race_bike", table_name="race_entries")
+    op.drop_table("race_entries")
+
+    op.drop_table("riders")
+
+    op.drop_index("idx_races_date_venue", table_name="races")
+    op.drop_table("races")
+
+    op.drop_table("venues")

--- a/apps/api/src/models/__init__.py
+++ b/apps/api/src/models/__init__.py
@@ -1,0 +1,17 @@
+from .base import Base
+from .venue import Venue
+from .race import Race
+from .rider import Rider
+from .race_entry import RaceEntry
+from .odds import Odds
+from .prediction import Prediction
+
+__all__ = [
+    "Base",
+    "Venue",
+    "Race",
+    "Rider",
+    "RaceEntry",
+    "Odds",
+    "Prediction",
+]

--- a/apps/api/src/models/base.py
+++ b/apps/api/src/models/base.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy import Integer, DateTime
+
+
+class Base(DeclarativeBase):
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )

--- a/apps/api/src/models/odds.py
+++ b/apps/api/src/models/odds.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from sqlalchemy import ForeignKey, Numeric, String, Index
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class Odds(Base):
+    __tablename__ = "odds"
+    __table_args__ = (
+        Index("idx_odds_race_bet", "race_id", "bet_type"),
+    )
+
+    race_id: Mapped[int] = mapped_column(ForeignKey("races.id"))
+    bet_type: Mapped[str] = mapped_column(String(20))
+    combo: Mapped[str] = mapped_column(String(20))
+    odds: Mapped[float] = mapped_column(Numeric(10, 2))

--- a/apps/api/src/models/prediction.py
+++ b/apps/api/src/models/prediction.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from sqlalchemy import ForeignKey, String, Index
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.dialects.postgresql import JSONB
+
+from .base import Base
+
+
+class Prediction(Base):
+    __tablename__ = "predictions"
+    __table_args__ = (Index("idx_pred_race", "race_id"),)
+
+    race_id: Mapped[int] = mapped_column(ForeignKey("races.id"))
+    model_version: Mapped[str] = mapped_column(String(50))
+    payload: Mapped[dict] = mapped_column(JSONB)

--- a/apps/api/src/models/race.py
+++ b/apps/api/src/models/race.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+from sqlalchemy import Date, DateTime, ForeignKey, Integer, String, UniqueConstraint, Index
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .base import Base
+from .venue import Venue
+
+
+class Race(Base):
+    __tablename__ = "races"
+    __table_args__ = (
+        UniqueConstraint("venue_id", "date", "race_no"),
+        Index("idx_races_date_venue", "date", "venue_id"),
+    )
+
+    venue_id: Mapped[int] = mapped_column(ForeignKey("venues.id"))
+    date: Mapped[date] = mapped_column(Date())
+    race_no: Mapped[int] = mapped_column(Integer())
+    name: Mapped[str] = mapped_column(String(100))
+    grade: Mapped[str] = mapped_column(String(20))
+    start_time: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+    venue: Mapped[Venue] = relationship(backref="races")

--- a/apps/api/src/models/race_entry.py
+++ b/apps/api/src/models/race_entry.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from sqlalchemy import ForeignKey, Integer, String, UniqueConstraint, Index
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class RaceEntry(Base):
+    __tablename__ = "race_entries"
+    __table_args__ = (
+        UniqueConstraint("race_id", "rider_id"),
+        Index("idx_entries_race_bike", "race_id", "bike_no", unique=True),
+    )
+
+    race_id: Mapped[int] = mapped_column(ForeignKey("races.id"))
+    rider_id: Mapped[int] = mapped_column(ForeignKey("riders.id"))
+    bike_no: Mapped[int] = mapped_column(Integer())
+    line_group: Mapped[str] = mapped_column(String(50))
+    handicap: Mapped[str | None] = mapped_column(String(50), nullable=True)

--- a/apps/api/src/models/rider.py
+++ b/apps/api/src/models/rider.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from sqlalchemy import Integer, String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class Rider(Base):
+    __tablename__ = "riders"
+    __table_args__ = (UniqueConstraint("registration_no"),)
+
+    registration_no: Mapped[int] = mapped_column(Integer())
+    name: Mapped[str] = mapped_column(String(100))
+    birthplace: Mapped[str] = mapped_column(String(100))
+    age: Mapped[int] = mapped_column(Integer())
+    klass: Mapped[str] = mapped_column(String(20))

--- a/apps/api/src/models/venue.py
+++ b/apps/api/src/models/venue.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from sqlalchemy import String, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .base import Base
+
+
+class Venue(Base):
+    __tablename__ = "venues"
+    __table_args__ = (UniqueConstraint("code"),)
+
+    code: Mapped[str] = mapped_column(String(10))
+    name: Mapped[str] = mapped_column(String(100))
+    prefecture: Mapped[str] = mapped_column(String(100))

--- a/apps/web/eslint.config.js
+++ b/apps/web/eslint.config.js
@@ -1,0 +1,17 @@
+import tseslint from '@typescript-eslint/eslint-plugin';
+import tsParser from '@typescript-eslint/parser';
+
+export default [
+  {
+    files: ['**/*.ts'],
+    languageOptions: {
+      parser: tsParser,
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'error',
+    },
+  },
+];

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "lint": "eslint . --ext .ts",
-    "test": "vitest"
+    "lint": "eslint .",
+    "test": "vitest run"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.21.0",


### PR DESCRIPTION
## Summary
- scaffold SQLAlchemy models for venues, races, riders, entries, odds, and predictions
- add Alembic configuration and initial migration
- configure ESLint for web package and adjust scripts

## Testing
- `pnpm -C apps/web lint`
- `pnpm -C apps/web test`
- `ruff check apps/api`
- `PYTHONPATH=apps/api pytest apps/api/tests/test_health.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b670addbb88326b747cbdde367ea61