### PR TITLE
feat: add initial ML feature and dataset utilities

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn
 pytest
 httpx
+pandas
 
 # Lint and format
 ruff

--- a/apps/api/src/ml/__init__.py
+++ b/apps/api/src/ml/__init__.py
@@ -1,0 +1,4 @@
+from .featureset import build_features
+from .datasets import make_datasets
+
+__all__ = ["build_features", "make_datasets"]

--- a/apps/api/src/ml/datasets.py
+++ b/apps/api/src/ml/datasets.py
@@ -1,0 +1,44 @@
+"""Dataset preparation utilities."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Tuple
+
+import pandas as pd
+
+
+def make_datasets(
+    df: pd.DataFrame, cutoff_date: date
+) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    """Split a dataframe into train/validation/test sets.
+
+    The split is performed using fixed windows relative to ``cutoff_date``:
+
+    - Train: data strictly before ``cutoff_date - 60 days``
+    - Validation: data in ``[cutoff_date - 60 days, cutoff_date - 14 days)``
+    - Test: data in ``[cutoff_date - 14 days, cutoff_date]``
+
+    Args:
+        df: DataFrame containing at least a ``date`` column of ``datetime64`` type.
+        cutoff_date: Reference end date for the split.
+
+    Returns:
+        A tuple of ``(train_df, valid_df, test_df)`` where each dataframe is indexed from zero.
+    """
+    train_end = cutoff_date - timedelta(days=60)
+    valid_end = cutoff_date - timedelta(days=14)
+
+    train_end_ts = pd.Timestamp(train_end)
+    valid_end_ts = pd.Timestamp(valid_end)
+    cutoff_ts = pd.Timestamp(cutoff_date)
+
+    train_df = df[df["date"] < train_end_ts]
+    valid_df = df[(df["date"] >= train_end_ts) & (df["date"] < valid_end_ts)]
+    test_df = df[(df["date"] >= valid_end_ts) & (df["date"] <= cutoff_ts)]
+
+    return (
+        train_df.reset_index(drop=True),
+        valid_df.reset_index(drop=True),
+        test_df.reset_index(drop=True),
+    )

--- a/apps/api/src/ml/featureset.py
+++ b/apps/api/src/ml/featureset.py
@@ -1,0 +1,33 @@
+"""Feature engineering utilities."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Optional, Tuple
+
+import pandas as pd
+
+
+def build_features(
+    *,
+    race_id: Optional[int] = None,
+    date_range: Optional[Tuple[date, date]] = None,
+) -> pd.DataFrame:
+    """Build features for a race or a date range.
+
+    Args:
+        race_id: Identifier of the target race. Mutually exclusive with ``date_range``.
+        date_range: Inclusive start and end dates. Mutually exclusive with ``race_id``.
+
+    Returns:
+        ``pandas.DataFrame`` containing engineered features.
+
+    Raises:
+        ValueError: If neither or both of ``race_id`` and ``date_range`` are provided.
+    """
+    if (race_id is None) == (date_range is None):
+        msg = "Either race_id or date_range must be provided, but not both"
+        raise ValueError(msg)
+
+    # TODO: implement feature extraction logic.
+    return pd.DataFrame()

--- a/apps/api/tests/test_datasets.py
+++ b/apps/api/tests/test_datasets.py
@@ -1,0 +1,17 @@
+from datetime import date
+
+import pandas as pd
+
+from src.ml.datasets import make_datasets
+
+
+def test_make_datasets_split() -> None:
+    df = pd.DataFrame({"date": pd.date_range("2024-01-01", periods=120)})
+    cutoff = date(2024, 4, 30)
+    train, valid, test = make_datasets(df, cutoff)
+
+    assert train["date"].max().date() < date(2024, 3, 1)
+    assert valid["date"].min().date() >= date(2024, 3, 1)
+    assert valid["date"].max().date() < date(2024, 4, 16)
+    assert test["date"].min().date() >= date(2024, 4, 16)
+    assert test["date"].max().date() <= cutoff

--- a/docs/ML_README.md
+++ b/docs/ML_README.md
@@ -1,0 +1,12 @@
+# ML Pipeline Overview
+
+This document outlines the machine learning components for Keirin AI. It covers
+feature engineering, dataset preparation, model training, and evaluation. The
+implementation is in progress and will be expanded as the project evolves.
+
+## Features
+- Placeholder feature extraction via `build_features`.
+- Dataset splitting utilities via `make_datasets`.
+
+Further sections will describe model architectures, calibration methods, and
+backtesting results once implemented.


### PR DESCRIPTION
## Summary
- scaffold ML module with `build_features` stub and dataset splitting utility
- document initial ML pipeline design
- add dataset split unit test and Pandas dependency

## Testing
- `ruff check apps/api/src/ml apps/api/tests`
- `mypy --explicit-package-bases src/ml tests`
- `PYTHONPATH=apps/api pytest apps/api/tests`
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67616dcf483268cca463a81773e4d