### PR TITLE
feat: add local dev tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,27 @@ PYTHONPATH=apps/api pytest
 ruff apps/api
 mypy apps/api
 ```
+
+## ローカルビルド&実行
+このリポジトリは Docker Compose と Taskfile を使った一括セットアップに対応しています。
+
+### 前提ツール
+- Node 20 LTS / pnpm 9
+- Python 3.11 / uv
+- Docker (BuildKit 有効)
+- go-task (タスクランナー)
+
+### 初期セットアップと起動
+`.env` テンプレートをコピーした後、以下を実行します。
+```bash
+task bootstrap
+task up
+```
+- UI: http://localhost:3000
+- API: http://localhost:8000/docs
+
+### 本番相当ビルド
+```bash
+task build
+```
+作成されたイメージを使用して `docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build` などで起動できます。

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,25 @@
+version: "3"
+env: { COMPOSE_DOCKER_CLI_BUILD: "1", DOCKER_BUILDKIT: "1" }
+tasks:
+  bootstrap:
+    desc: 初期セットアップ（依存導入・マイグレ・サンプル投入）
+    cmds:
+      - pnpm -C apps/web install
+      - uv sync -p apps/api
+      - docker compose up -d db
+      - docker compose exec api alembic upgrade head
+      - docker compose run --rm etl python -m apps.etl.cli daily --date {{.DATE | default (env "DATE") | default (shell "date +%F")}}
+  up:
+    desc: web/api/db を起動
+    cmds: [ "docker compose up web api db" ]
+  build:
+    desc: すべてのイメージをビルド
+    cmds: [ "docker compose build --no-cache" ]
+  test:
+    desc: 単体/統合テスト実行
+    cmds:
+      - pnpm -C apps/web test
+      - docker compose exec api pytest -q
+  down:
+    desc: 停止と後片付け
+    cmds: [ "docker compose down -v" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,25 @@
-version: '3.9'
-
+version: "3.9"
 services:
-  api:
-    build:
-      context: ./apps/api
-      dockerfile: ../../docker/api.Dockerfile
-    command: uvicorn src.main:app --host 0.0.0.0 --port 8000
-    volumes:
-      - ./apps/api:/app
-    ports:
-      - "8000:8000"
   db:
     image: postgres:15
     environment:
+      POSTGRES_DB: keirin
       POSTGRES_USER: keirin
       POSTGRES_PASSWORD: keirin
-      POSTGRES_DB: keirin
-    ports:
-      - "5432:5432"
+    ports: ["5432:5432"]
+    volumes: ["pgdata:/var/lib/postgresql/data"]
+    healthcheck: { test: ["CMD-SHELL","pg_isready -U keirin"], interval: 5s, timeout: 3s, retries: 10 }
+  api:
+    build: { context: ./apps/api, dockerfile: ../../docker/api.Dockerfile }
+    env_file: [.env.development]
+    depends_on: { db: { condition: service_healthy } }
+    ports: ["8000:8000"]
+    command: ["uvicorn","src.main:app","--host","0.0.0.0","--port","8000"]
+    develop: { watch: [{ path: ./apps/api, action: sync, target: /app, ignore: ["__pycache__"] }] }
+  web:
+    build: { context: ./apps/web, dockerfile: ../../docker/web.Dockerfile }
+    env_file: [.env.development]
+    ports: ["3000:3000"]
+    command: ["pnpm","dev","-o"]
+    develop: { watch: [{ path: ./apps/web, action: sync, target: /app }] }
+volumes: { pgdata: {} }

--- a/docker/api.Dockerfile
+++ b/docker/api.Dockerfile
@@ -1,6 +1,16 @@
-FROM python:3.11-slim
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim AS base
+RUN pip install --no-cache-dir uv
 WORKDIR /app
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
+
+FROM base AS deps
+COPY apps/api/requirements.txt .
+RUN uv pip install --system --no-cache -r requirements.txt
+
+FROM python:3.11-slim AS runtime
+WORKDIR /app
+COPY --from=deps /usr/local /usr/local
+COPY apps/api/ ./
+USER 1001
+HEALTHCHECK CMD curl -f http://localhost:8000/healthz || exit 1
 CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker/web.Dockerfile
+++ b/docker/web.Dockerfile
@@ -1,0 +1,17 @@
+# syntax=docker/dockerfile:1
+FROM node:20 AS base
+WORKDIR /app
+
+FROM base AS build
+COPY apps/web/package.json apps/web/pnpm-lock.yaml ./
+RUN corepack enable && pnpm install --frozen-lockfile
+COPY apps/web/ .
+ARG NODE_ENV=production
+RUN pnpm build
+
+FROM node:20 AS runtime
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=build /app/.output ./.output
+EXPOSE 3000
+CMD ["node", ".output/server/index.mjs"]


### PR DESCRIPTION
## Summary
- add Taskfile for bootstrap, up, build, test, down tasks
- add multi-stage Dockerfiles for API and web services
- update docker-compose with API, web, and Postgres
- document local build and execution steps

## Testing
- `pnpm lint`
- `pnpm test`
- `PYTHONPATH=apps/api pytest` (fails: ModuleNotFoundError: No module named 'pandas')
- `ruff check apps/api`
- `mypy apps/api` (fails: Cannot find implementation or library stub for module named "src.models")

------
https://chatgpt.com/codex/tasks/task_e_68b681e2cc88832687f6a637ea8004c3